### PR TITLE
chore(ci): use go-version-file and rename linter task to lint

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
-          go-version: stable
+          go-version-file: 'go.mod'
       - name: Install task
         uses: jaxxstorm/action-install-gh-release@v1.12.0
         with:
@@ -31,4 +31,4 @@ jobs:
       - name: Run linter
         shell: /usr/bin/bash {0}
         run: |
-          task linter
+          task lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.24'
+          go-version-file: 'go.mod'
       - name: Install task
         uses: jaxxstorm/action-install-gh-release@v1.12.0
         with:

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.24'
+          go-version-file: 'go.mod'
       - name: Install task
         uses: jaxxstorm/action-install-gh-release@v1.12.0
         with:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -15,7 +15,7 @@ tasks:
     cmds:
       - go build .
 
-  linter:
+  lint:
     desc: "Run the linter"
     cmds:
       - golangci-lint run


### PR DESCRIPTION
- Replace hardcoded go-version with go-version-file: 'go.mod' in
  linter, release, and snapshot workflows
- Rename Taskfile task 'linter' to 'lint' for consistency

Refs #12